### PR TITLE
update from zheddie/somr

### DIFF
--- a/TestSuite/ObjectSizeTest.som
+++ b/TestSuite/ObjectSizeTest.som
@@ -28,31 +28,31 @@ THE SOFTWARE.
 ObjectSizeTest = (
 
     run: harness = (
-        Object new objectSize / 4 = 6
+        Object new objectSize / 4 = 12
             ifFalse: [
                 harness
                     fail: self
-                    because: 'Plain object does not have size 6.' ].
-        42 objectSize / 4 = 7
+                    because: 'Plain object does not have size 12.' ].
+        42 objectSize / 4 = 13
             ifFalse: [
                 harness
                     fail: self
-                    because: 'Integer object does not have size 7.' ].
-        'hello' objectSize / 4 = 9
+                    because: 'Integer object does not have size 13.' ].
+        'hello' objectSize / 4 = 14
             ifFalse: [
                 harness
                     fail: self
-                    because: 'hello String object does not have size 9.' ].
-        Array new objectSize / 4 = 6
+                    because: 'hello String object does not have size 14.' ].
+        Array new objectSize / 4 = 12
             ifFalse: [
                 harness
                     fail: self
-                    because: 'Empty array object does not have size 6.' ].
-        (Array new: 4) objectSize / 4 = 10
+                    because: 'Empty array object does not have size 12.' ].
+        (Array new: 4) objectSize / 4 = 16
             ifFalse: [
                 harness
                     fail: self
-                    because: 'Array object (length 4) does not have size 10.' ].
+                    because: 'Array object (length 4) does not have size 16.' ].
     )
     
 )

--- a/src/compiler/Disassembler.cpp
+++ b/src/compiler/Disassembler.cpp
@@ -358,7 +358,7 @@ void Disassembler::DumpBytecode(pVMFrame frame, pVMMethod method, int bc_idx) {
                 
                 c_cname = cname->GetChars();
             } else
-                c_cname = "NULL";
+                c_cname = (char *) "NULL";
             
             DebugPrint("(index: %d)value: %s <(%s) ", BC_1,
                         name->GetChars(), c_cname);

--- a/src/glue/CollectorLanguageInterfaceImpl.cpp
+++ b/src/glue/CollectorLanguageInterfaceImpl.cpp
@@ -184,13 +184,12 @@ MM_CollectorLanguageInterfaceImpl::markingScheme_masterCleanupAfterGC(MM_Environ
 uintptr_t
 MM_CollectorLanguageInterfaceImpl::markingScheme_scanObject(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, MarkingSchemeScanReason reason)
 {
-	GC_ObjectIterator objectIterator(_omrVM, objectPtr);
-	GC_SlotObject *slotObject = NULL;
-	while (NULL != (slotObject = objectIterator.nextSlot())) {
-		omrobjectptr_t slot = slotObject->readReferenceFromSlot();
-		if (_markingScheme->isHeapObject(slot)) {
-			_markingScheme->markObject(env, slot);
-		}
+	int totalfields = ((pVMObject)objectPtr)->GetNumberOfMarkableFields();
+	for(int i =0 ; i<totalfields;i++){
+		omrobjectptr_t  onefield = (omrobjectptr_t)(((pVMObject)objectPtr)->GetMarkableFieldObj(i));
+			if (NULL != onefield && _markingScheme->isHeapObject(onefield)) {
+				_markingScheme->markObject(env, onefield);
+			}
 	}
 	return env->getExtensions()->objectModel.getSizeInBytesWithHeader(objectPtr);
 }

--- a/src/glue/StartupManagerImpl.hpp
+++ b/src/glue/StartupManagerImpl.hpp
@@ -66,7 +66,7 @@ public:
 //#endif /* defined(OMR_GC_SEGREGATED_HEAP) */
 //	{
 //	}
-	MM_StartupManagerImpl(OMR_VM *omrVM,uintptr_t maxSize=2*1024*1024)
+	MM_StartupManagerImpl(OMR_VM *omrVM,uintptr_t maxSize=128*1024*1024)
 		: MM_StartupManager(omrVM, defaultMinimumHeapSize, maxSize)
 #if defined(OMR_GC_SEGREGATED_HEAP)
 		, _useSegregatedGC(false)

--- a/src/glue/UtilGlue.c
+++ b/src/glue/UtilGlue.c
@@ -17,6 +17,8 @@
  *******************************************************************************/
 
 #include "omr.h"
+#include <string.h>
+#include <stdlib.h>
 
 /* This glue function is implemented in a different file from LanguageVMGlue so that
  * it can be used without requiring all the dependencies of LanguageVMGlue.
@@ -38,5 +40,8 @@ OMR_Glue_GetVMDirectoryToken(void **token)
 char *
 OMR_Glue_GetThreadNameForUnamedThread(OMR_VMThread *vmThread)
 {
-	return "(unnamed thread)";
+	char * p = (char *)malloc(sizeof("(unnamed thread)")+1);
+	memset(p,0,sizeof("(unnamed thread)")+1);
+	strcpy(p,"(unnamed thread)");
+	return p;
 }

--- a/src/interpreter/Interpreter.cpp
+++ b/src/interpreter/Interpreter.cpp
@@ -238,8 +238,9 @@ void Interpreter::doPushField( int bytecodeIndex ) {
 void Interpreter::doPushBlock( int bytecodeIndex ) {
     pVMMethod method = _METHOD;
 
-    pVMMethod blockMethod = (pVMMethod)(method->GetConstant(bytecodeIndex));
 
+    pVMObject  po =method->GetConstant(bytecodeIndex);
+    pVMMethod blockMethod = (pVMMethod)(po);
     int numOfArgs = blockMethod->GetNumberOfArguments();
 
     _FRAME->Push((pVMObject) _UNIVERSE->NewBlock(blockMethod, _FRAME,

--- a/src/memory/Heap.cpp
+++ b/src/memory/Heap.cpp
@@ -157,30 +157,15 @@ VMObject* Heap::AllocateObject(size_t s) {
 //	
 	uintptr_t size = extensions->objectModel.adjustSizeInBytes(s);
 	//
+	if( size < s){//Impossible,.
+		printf("zg.ERROR!!%s,%s,%s\n",__FILE__,__FUNCTION__,__LINE__);
+		exit(1);
+	}
     VMObject* vmo = (VMObject*) Allocate(size);
     if(vmo != NULL){
     vmo->SetObjectSize(s);  //zg. save the requested size.
     //TODO: How to do so? zg.add this object into the objectTable.??How to define the name of it.
-//    
-   numAlloc++;
-   char * name =(char *)malloc(10);
-   memset(name,10,0);
-  sprintf(name,"obj%d",numAlloc);
-//  
-  // pVMSymbol psName =  _UNIVERSE->SymbolForChars(name);
-//   
-    ObjectEntry oEntry = {name,(omrobjectptr_t)vmo,0};
-//    
-	ObjectEntry *entryInTable = (ObjectEntry *)hashTableAdd(_vm->objectTable, &oEntry);
-//	 
-	OMRPORT_ACCESS_FROM_OMRVM(_vm->_omrVM);
-	if (NULL == entryInTable) {
-		omrtty_printf("failed to add new obect to objecttable!\n");
-	}
-	/* update entry if it already exists in table */
-	entryInTable->objPtr = (omrobjectptr_t)vmo;
-//	 
-   // exampleVM.objectTable->
+
     }
     return vmo;
 }
@@ -200,6 +185,8 @@ void* Heap::Allocate(size_t size) {
 	if (NULL != obj) {
 		extensions->objectModel.setObjectSize(obj, mm_allocdescription.getBytesRequested());
 		//((VMObject *) obj )->SetObjectSize(size);   //zg. no need to set.  as it's already in the first word( 4 bytes) .  The first byte is reserved for age&flag, and the remains 3 bytes are for size.
+	}else{
+		std::cout <<"ERROR: allocation failure."<<std::endl;
 	}
 
 

--- a/src/memory/Heap.h
+++ b/src/memory/Heap.h
@@ -81,7 +81,7 @@ public:
    // void PrintFreeList();
     
     void FullGC();
-	
+    OMR_VM_Example * getVM(){return _vm;}
     
 private:
     static class Heap * theHeap;

--- a/src/vm/Universe.cpp
+++ b/src/vm/Universe.cpp
@@ -710,12 +710,12 @@ pVMBlock Universe::NewBlock( pVMMethod method, pVMFrame context, int arguments) 
 
     result->SetMethod(method);
     result->SetContext(context);
-
+    this->SetGlobal(method->GetSignature(),(pVMObject)result);
     return result;
 }
 
 
-pVMClass Universe::NewClass( pVMClass classOfClass) const {
+pVMClass Universe::NewClass( pVMClass classOfClass)  {
     int numFields = classOfClass->GetNumberOfInstanceFields();
     pVMClass result;
     int additionalBytes = numFields * sizeof(pVMObject);
@@ -723,7 +723,7 @@ pVMClass Universe::NewClass( pVMClass classOfClass) const {
     else result = new (_HEAP) VMClass;
 
     result->SetClass(classOfClass);
-
+    this->SetGlobal(SymbolForChars("NewClass"),(pVMObject)result);
     return result;
 }
 
@@ -735,7 +735,7 @@ pVMDouble Universe::NewDouble( double value) const {
 }
 
 
-pVMFrame Universe::NewFrame( pVMFrame previousFrame, pVMMethod method) const {
+pVMFrame Universe::NewFrame( pVMFrame previousFrame, pVMMethod method)  {
     int length = method->GetNumberOfArguments() +
                  method->GetNumberOfLocals()+
                  method->GetMaximumNumberOfStackElements(); 
@@ -751,7 +751,8 @@ pVMFrame Universe::NewFrame( pVMFrame previousFrame, pVMMethod method) const {
 
     result->ResetStackPointer();
     result->SetBytecodeIndex(0);
-
+    //zg.don't we need to set it as global?
+   this->SetGlobal(frameClass->GetName(),(pVMObject)result);
     return result;
 }
 
@@ -785,7 +786,7 @@ pVMClass Universe::NewMetaclassClass() const {
 
 
 pVMMethod Universe::NewMethod( pVMSymbol signature, 
-                    size_t numberOfBytecodes, size_t numberOfConstants) const {
+                    size_t numberOfBytecodes, size_t numberOfConstants)  {
     //Method needs space for the bytecodes and the pointers to the constants
     int additionalBytes = numberOfBytecodes + 
                 numberOfConstants*sizeof(pVMObject);
@@ -794,7 +795,8 @@ pVMMethod Universe::NewMethod( pVMSymbol signature,
     result->SetClass(methodClass);
 
     result->SetSignature(signature);
-
+    //zg.don't we need to set it as global?
+     this->SetGlobal(signature,(pVMObject)result);
     return result;
 }
 
@@ -827,14 +829,14 @@ pVMSymbol Universe::NewSymbol( const char* str ) {
 }
 
 
-pVMClass Universe::NewSystemClass() const {
+pVMClass Universe::NewSystemClass()  {
     pVMClass systemClass = new (_HEAP) VMClass();
 
     systemClass->SetClass(new (_HEAP) VMClass());
     pVMClass mclass = systemClass->GetClass();
     
     mclass->SetClass(metaClassClass);
-
+    this->SetGlobal(SymbolForChars("SystemClass"),(pVMObject)systemClass);
     return systemClass;
 }
 

--- a/src/vm/Universe.h
+++ b/src/vm/Universe.h
@@ -117,9 +117,9 @@ public:
     pVMArray      NewArrayList(ExtendedList<pVMObject>& list) const;
     pVMArray      NewArrayFromArgv(const vector<StdString>&) const;
     pVMBlock      NewBlock(pVMMethod, pVMFrame, int);
-    pVMClass      NewClass(pVMClass) const;
-    pVMFrame      NewFrame(pVMFrame, pVMMethod) const;
-    pVMMethod     NewMethod(pVMSymbol, size_t, size_t) const;
+    pVMClass      NewClass(pVMClass) ;
+    pVMFrame      NewFrame(pVMFrame, pVMMethod) ;
+    pVMMethod     NewMethod(pVMSymbol, size_t, size_t) ;
     pVMObject     NewInstance(pVMClass) const;
     pVMInteger    NewInteger(int32_t) const;
     pVMBigInteger NewBigInteger(int64_t) const;
@@ -129,7 +129,7 @@ public:
     pVMSymbol     NewSymbol(const StdString&);
     pVMString     NewString(const char*) const;
     pVMSymbol     NewSymbol(const char*);
-    pVMClass      NewSystemClass(void) const;
+    pVMClass      NewSystemClass(void) ;
 
     void          InitializeSystemClass(pVMClass, pVMClass, const char*);
 

--- a/src/vmobjects/VMClass.cpp
+++ b/src/vmobjects/VMClass.cpp
@@ -167,6 +167,9 @@ pVMObject VMClass::LookupInvokable(pVMSymbol name) const {
     pVMInvokable invokable = NULL;
     for (int i = 0; i < GetNumberOfInstanceInvokables(); ++i) {
         invokable = (pVMInvokable)(GetInstanceInvokable(i));
+        if( NULL == invokable){
+        	break;
+        }
         if (invokable->GetSignature() == name) 
             return (pVMObject)(invokable);
     }

--- a/src/vmobjects/VMEvaluationPrimitive.cpp
+++ b/src/vmobjects/VMEvaluationPrimitive.cpp
@@ -50,6 +50,19 @@ VMEvaluationPrimitive::VMEvaluationPrimitive(int argc) :
 }
 
 
+int       VMEvaluationPrimitive::GetNumberOfMarkableFields() const
+{return GetNumberOfFields()- 2+1;}
+
+pVMObject       VMEvaluationPrimitive::GetMarkableFieldObj(int idx) const {
+	 int mfn = GetNumberOfMarkableFields();
+	 if(idx <mfn -1 ){
+		 return (pVMObject) FIELDS[idx];
+	 }else if (idx== mfn-1){		//This extra for this object.
+		 return (pVMObject)numberOfArguments;
+	 }else {
+		 return NULL;
+	 }
+}
 void VMEvaluationPrimitive::MarkReferences() {
     VMPrimitive::MarkReferences();
     this->numberOfArguments->MarkReferences();

--- a/src/vmobjects/VMEvaluationPrimitive.h
+++ b/src/vmobjects/VMEvaluationPrimitive.h
@@ -38,7 +38,8 @@ class VMFrame;
 class VMEvaluationPrimitive : public VMPrimitive {
 public:
     VMEvaluationPrimitive(int argc);
-    
+    virtual pVMObject       GetMarkableFieldObj(int ) const;
+   virtual  int       GetNumberOfMarkableFields() const;
     virtual void MarkReferences();
 private:
     static pVMSymbol computeSignatureString(int argc);

--- a/src/vmobjects/VMFrame.cpp
+++ b/src/vmobjects/VMFrame.cpp
@@ -134,7 +134,8 @@ void      VMFrame::Push(pVMObject obj) {
 
 void VMFrame::PrintStack() const {
     cout << "SP: " << this->stackPointer->GetEmbeddedInteger() << endl;
-    for (int i = 0; i < this->GetNumberOfIndexableFields()+1; ++i) {
+   // for (int i = 0; i < this->GetNumberOfIndexableFields()+1; ++i) {
+    for (int i = 0; i < this->GetNumberOfIndexableFields(); ++i) {
         pVMObject vmo = (*this)[i];
         cout << i << ": ";
         if (vmo == NULL) 

--- a/src/vmobjects/VMObject.h
+++ b/src/vmobjects/VMObject.h
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include "../vm/Universe.h"
 #include "ObjectModel.hpp"
 
+#include "omrExampleVM.hpp"
 #include "ObjectFormats.h"
 #include "GCExtensionsBase.hpp"
 class VMSymbol;
@@ -59,7 +60,7 @@ class VMClass;
  **************************************************************
  */
 class OMRObjectHeader{
-private:
+public:
 	int32_t reserved;	//Reserved for OMR used.
 	int32_t reserved_align; //Align to the 0x8, These 4 bytes are no use now.
 };
@@ -74,6 +75,14 @@ public:
 	virtual void        SetClass(pVMClass cl);
 	virtual pVMSymbol   GetFieldName(int index) const; 
 	virtual int         GetFieldIndex(pVMSymbol fieldName) const;
+	//zg.add start
+	virtual int       GetNumberOfIndexableFields() const {return 0;};
+	virtual int       GetNumberOfMarkableFields() const {return GetNumberOfFields()+GetNumberOfIndexableFields();};
+	virtual pVMObject       GetMarkableFieldObj(int idx) const ;
+	//This impl may not workable for some class (such as VMInteger, but it only make sense for the class which has at lease one indexableFields. We can only focus on the VMARray and VMMethods
+	virtual pVMObject * GetStartOfAdditionalPoint() const{ return &(FIELDS[this->GetNumberOfFields()]);};
+   virtual void addToObjectTable();
+	//zg.add end.
 	virtual int         GetNumberOfFields() const;
 	virtual void        SetNumberOfFields(int nof);
 	virtual int         GetDefaultNumberOfFields() const;
@@ -86,7 +95,7 @@ public:
     virtual void        IncreaseGCCount() {};
     virtual void        DecreaseGCCount() {};
     //virtual void setObjectType(const char * ot) {strncpy(objectType,ot,OTLEN-1); objectType[OTLEN-1]=0;}
-     char * getObjectType(){return objectType;}
+     char * getObjectType() const {return (char *)objectType;}
     int32_t     GetHash() const { return hash; };
     int32_t     GetObjectSize() const;
 	int32_t     GetGCField() const;

--- a/src/vmobjects/VMPrimitive.cpp
+++ b/src/vmobjects/VMPrimitive.cpp
@@ -57,7 +57,8 @@ VMPrimitive::VMPrimitive(pVMSymbol signature) : VMInvokable(VMPrimitiveNumberOfF
     _HEAP->EndUninterruptableAllocation();
 }
 
-
+int       VMPrimitive::GetNumberOfMarkableFields() const
+{return GetNumberOfFields()- VMPrimitiveNumberOfFields;}
 
 void VMPrimitive::MarkReferences() {
     if (gcfield) return;

--- a/src/vmobjects/VMPrimitive.h
+++ b/src/vmobjects/VMPrimitive.h
@@ -44,6 +44,7 @@ public:
     
     virtual inline bool    IsEmpty() const;
     virtual inline void    SetRoutine(PrimitiveRoutine* rtn);
+    virtual int       GetNumberOfMarkableFields() const;
     virtual void    MarkReferences();
     virtual void    SetEmpty(bool value) { empty = value; };
 


### PR DESCRIPTION
Main changes:
1) remove the use of objectiterator, and use some virutual methods in VM objects instead to let OMR go through each field of one object.
2) Do not add the object to objecttable in Heap, move it to VMObject's contructor instead. Although this still NOT work. :-(.
